### PR TITLE
🛁 Clean react component props

### DIFF
--- a/src/tag.js
+++ b/src/tag.js
@@ -7,7 +7,7 @@ const tag = (blacklist = []) => {
     const Base = props => {
       const isEl = typeof type === 'string'
       const Comp = isEl ? (props.is || type) : type
-      const next = isEl ? clean(props) : props
+      const next = clean(props)
 
       if (isEl) next.is = null
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,13 @@ test('cleans props', () => {
   expect(json.props.pass).toBe('through')
 })
 
+test('cleans React Component props', () => {
+  Comp = tag([ 'foo' ])(props => <div {...props} />)
+  const json = render(<Comp foo='boop' pass='through' />).toJSON()
+  expect(json.props.foo).toBeUndefined()
+  expect(json.props.pass).toBe('through')
+})
+
 test('defaults to an empty array for propsToRemove argument', () => {
   Comp = tag()('div')
   const json = render(<Comp foo='boop' />).toJSON()


### PR DESCRIPTION
Currently, if `type` is a function (or React Component) the props are propagated down without being cleaned.

I'm trying to figure out a fix for https://github.com/jxnblk/rebass/issues/330.
The problem is `Row`, `Column`, `Flex`, & `Box` are styled-components which are functions.

