### PR TITLE
Make created Tag component a class

### DIFF
--- a/src/tag.js
+++ b/src/tag.js
@@ -4,14 +4,17 @@ const tag = (blacklist = []) => {
   const clean = cleanProps(blacklist)
 
   return type => {
-    const Base = props => {
-      const isEl = typeof type === 'string'
-      const Comp = isEl ? (props.is || type) : type
-      const next = isEl ? clean(props) : props
-
-      if (isEl) next.is = null
-
-      return <Comp {...next} />
+    class Base extends React.Component {
+      render() {
+        const props = this.props;
+        const isEl = typeof type === 'string'
+        const Comp = isEl ? (props.is || type) : type
+        const next = isEl ? clean(props) : props
+  
+        if (isEl) next.is = null
+  
+        return <Comp {...next} />
+      }
     }
 
     return Base


### PR DESCRIPTION
This avoids issues with refs in React which are difficult to control or manage from higher up.

See https://github.com/jxnblk/grid-styled/issues/44 for context.